### PR TITLE
fix: manager sidebar toont alleen manager-items, niet ook medewerker-…

### DIFF
--- a/frontend/components/ModernSidebar.tsx
+++ b/frontend/components/ModernSidebar.tsx
@@ -173,7 +173,7 @@ export function ModernSidebar({
     if (userRank === "admin") {
       items = [...adminMenuItems, ...getWerknemerMenuItems(t)];
     } else if (userRank === "manager") {
-      items = [...managerMenuItems, ...getWerknemerMenuItems(t)];
+      items = [...managerMenuItems];
     }
 
     const uniqueItems = items.filter(


### PR DESCRIPTION
…items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation Updates**
  * Updated the menu navigation for manager-level users to display only manager-specific menu items, removing duplicate employee menu entries from their view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->